### PR TITLE
Queue RPC Implementation

### DIFF
--- a/src/components/QueueActions.svelte
+++ b/src/components/QueueActions.svelte
@@ -64,6 +64,7 @@
 		<select
 			class="w-2/4 mx-auto mt-4 flex transition duration-200 hover:bg-gray-800 bg-gray-700 bg-opacity-100 text-white focus:text-themable-400 rounded-xl border border-white/10 focus:border-themable-400 focus:outline-none py-2 px-6"
 			on:click={openSelect}
+   on:change={() => { Action.onSelect("", "") }}
 		>
 			{#each Actions as Action}
 				<option value={Action.Name}>{Action.Name}</option>

--- a/src/components/QueueActions.svelte
+++ b/src/components/QueueActions.svelte
@@ -3,11 +3,9 @@
 
 	export let Actions: QueueActions[] = [];
 	export let disabled: boolean = false;
-
 	export let seperate: boolean = false;
 	export let fullButton: boolean = false;
 	export let open: boolean = false;
-
 	export let selectOpen: boolean = false;
 
 	const openDropdown = () => {

--- a/src/lib/comp_types/QueueActions.ts
+++ b/src/lib/comp_types/QueueActions.ts
@@ -8,4 +8,5 @@ export default interface Action {
 	Name: string;
 	Fields: ActionField[] | null;
 	Disabled: boolean;
+ onSelect: async () => Promise<void>;
 }

--- a/src/lib/comp_types/QueueActions.ts
+++ b/src/lib/comp_types/QueueActions.ts
@@ -8,5 +8,5 @@ export default interface Action {
 	Name: string;
 	Fields: ActionField[] | null;
 	Disabled: boolean;
- onSelect: async () => Promise<void>;
+ onSelect: async (targetID: string, reason: string | null) => Promise<void>;
 }

--- a/src/routes/panel/queue/bots/+page.svelte
+++ b/src/routes/panel/queue/bots/+page.svelte
@@ -80,8 +80,8 @@
 
 		if (res.ok) {
 			// Success
-			console.log('success');
-		} else console.log('bruh');
+			window.alert("[RPC Action] => Success!");
+		} else window.alert(`[RPC Action] => Failed! ({await res.json()})`);
 	};
 
 	const Actions: QueueActionTypes[] = [
@@ -93,19 +93,19 @@
 		},
 		{
 			Name: 'Unclaim',
-			Fields: [{ reason: string }],
+			Fields: [{ Name: "Reason", Answer: "", Validate: () => { return true } }],
 			Disabled: true,
    onSelect: async (targetID, reason) => { await QueueRPCActions(targetID, false, reason, RPCAction.Unclaim) }
 		},
 		{
 			Name: 'Approve',
-			Fields: [{ reason: string }],
+			Fields: [{ Name: "Reason", Answer: "", Validate: () => { return true } }],
 			Disabled: true,
    onSelect: async (targetID, reason) => { await QueueRPCActions(targetID, false, reason, RPCAction.Approve) }
 		},
 		{
 			Name: 'Deny',
-			Fields: [{ reason: string }],
+			Fields: [{ Name: "Reason", Answer: "", Validate: () => { return true } }],
 			Disabled: true,
    onSelect: async (targetID, reason) => { await QueueRPCActions(targetID, false, reason, RPCAction.Deny) }
 		}

--- a/src/routes/panel/queue/bots/+page.svelte
+++ b/src/routes/panel/queue/bots/+page.svelte
@@ -88,22 +88,26 @@
 		{
 			Name: 'Claim',
 			Fields: null,
-			Disabled: false
+			Disabled: false,
+   onSelect: async (targetID, reason = "") => { await QueueRPCActions(targetID, false, reason, RPCAction.Claim) }
 		},
 		{
 			Name: 'Unclaim',
-			Fields: null,
-			Disabled: true
+			Fields: [{ reason: string }],
+			Disabled: true,
+   onSelect: async (targetID, reason) => { await QueueRPCActions(targetID, false, reason, RPCAction.Unclaim) }
 		},
 		{
 			Name: 'Approve',
-			Fields: null,
-			Disabled: true
+			Fields: [{ reason: string }],
+			Disabled: true,
+   onSelect: async (targetID, reason) => { await QueueRPCActions(targetID, false, reason, RPCAction.Approve) }
 		},
 		{
 			Name: 'Deny',
-			Fields: null,
-			Disabled: true
+			Fields: [{ reason: string }],
+			Disabled: true,
+   onSelect: async (targetID, reason) => { await QueueRPCActions(targetID, false, reason, RPCAction.Deny) }
 		}
 	];
 </script>


### PR DESCRIPTION
This adds somewhat functionality to the Actions select menu on the Queue page that allows staff members to deal with bots currently in the queue with actions such as Claim, Unclaim, Approve, Deny. This is still a work in progress, but should be done later today